### PR TITLE
Fixed guide section "Run SystemC simulation"

### DIFF
--- a/doc/install.tex
+++ b/doc/install.tex
@@ -206,8 +206,7 @@ $ cat sv_out/counter.sv              # see generated SystemVerilog file
 
 SystemC simulation for examples and tests can be run with:
 \begin{lstlisting}[language=bash]
-$ cd $ICSC_HOME
-$ cd build
+$ cd $ICSC_HOME/build
 $ cmake ../                          # prepare Makefiles 
 $ make counter                       # compile SystemC simulation for counter example
 $ cd icsc/examples/counter                # go to counter example folder

--- a/doc/install.tex
+++ b/doc/install.tex
@@ -207,10 +207,10 @@ $ cat sv_out/counter.sv              # see generated SystemVerilog file
 SystemC simulation for examples and tests can be run with:
 \begin{lstlisting}[language=bash]
 $ cd $ICSC_HOME
-$ mkdir build && cd build
+$ cd build
 $ cmake ../                          # prepare Makefiles 
 $ make counter                       # compile SystemC simulation for counter example
-$ cd examples/counter                # go to counter example folder
+$ cd icsc/examples/counter                # go to counter example folder
 $ ./counter                          # run SystemC simulation 
 \end{lstlisting}
 

--- a/doc/install.tex
+++ b/doc/install.tex
@@ -209,7 +209,7 @@ SystemC simulation for examples and tests can be run with:
 $ cd $ICSC_HOME/build
 $ cmake ../                          # prepare Makefiles 
 $ make counter                       # compile SystemC simulation for counter example
-$ cd icsc/examples/counter                # go to counter example folder
+$ cd icsc/examples/counter           # go to counter example folder
 $ ./counter                          # run SystemC simulation 
 \end{lstlisting}
 


### PR DESCRIPTION
On second command, it is not required to do "mkdir build" since build directory already exists. The counter example folder is in "build/icsc/examples", not "build/examples".